### PR TITLE
Implementation of PML to 2 dimensional FDTD with a relective coefficient test

### DIFF
--- a/fdtd2d.py
+++ b/fdtd2d.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.animation as animation
 
 MU0 = 1.0
 EPS0 = 1.0
@@ -14,31 +15,66 @@ class FDTD2D:
         self.ny = len(yE)
         self.dx = xE[1] - xE[0]
         self.dy = yE[1] - yE[0]
+        self.condx = np.zeros_like(self.xE)  # Default conductivity is 0 everywheree
+        self.condy = np.zeros_like(self.yE)
+        self.condPMLx=np.zeros_like(self.xE) # Fake PML magnetic conductivty
+        self.condPMLy=np.zeros_like(self.yE)
 
         # TE mode fields: Hz (magnetic field in z), Ex (electric field in x), Ey (electric field in y)
-        self.Hz = np.zeros((self.nx, self.ny))
+        self.Hzx = np.zeros((self.nx, self.ny))
+        self.condPMLx = 1*self.Hzx
+        self.Hzy = np.zeros((self.nx, self.ny))
+        self.condPMLy = 1*self.Hzy
         self.Ex = np.zeros((self.nx, self.ny-1))
+        self.condy = 1*self.Ex
         self.Ey = np.zeros((self.nx-1, self.ny))
+        self.condx = 1*self.Ey
+        self.Hz = np.zeros((self.nx, self.ny))
         self.initialized = False
 
     def set_initial_condition(self, initial_condition):
         self.Hz[:] = initial_condition[:, :]
+        self.Hzx[:] = initial_condition[:, :]
+        self.Hzy[:] = initial_condition[:, :]
         self.initialized = True
+
+    def set_PML(self, thicknessPML, m, R0, dx):
+        sigmaMax = (-np.log(R0) * (m + 1)) / (2 * thicknessPML * dx)
+
+        for i in range(1, thicknessPML):
+            sigmai = sigmaMax * ((thicknessPML - i) / thicknessPML) ** m
+
+            # Apply PML to the X-axis boundaries
+            self.condPMLx[i, :] = sigmai
+            self.condPMLx[-i, :] = sigmai
+            self.condx[i, :] = sigmai
+            self.condx[-i, :] = sigmai
+
+            # Apply PML to the Y-axis boundaries
+            self.condPMLy[:, i] = sigmai
+            self.condPMLy[:, -i] = sigmai
+            self.condy[:, i] = sigmai
+            self.condy[:, -i] = sigmai
 
     def step(self, dt):
         if not self.initialized:
             raise RuntimeError(
                 "Initial condition not set. Call set_initial_condition first.")
 
-        self.Ex[:, :] = self.Ex[:, :] + dt / EPS0 / \
-            self.dy * (self.Hz[:, 1:] - self.Hz[:, :-1])
-        self.Ey[:, :] = self.Ey[:, :] - dt / EPS0 / \
-            self.dx * (self.Hz[1:, :] - self.Hz[:-1, :])
+        # Update electric field
+        self.Ex[:, :] = ( 1 / (2 * EPS0 + self.condy * dt) ) *  ( (2 * EPS0 - self.condy * dt) * self.Ex[:, :] + ( ( 2 * dt ) / \
+            self.dy ) * (self.Hz[:, 1:] - self.Hz[:, :-1]) )
+        self.Ey[:, :] = ( 1 / (2 * EPS0 + self.condx * dt) ) * ( (2 * EPS0 - self.condx * dt) * self.Ey[:, :] - ( ( 2 * dt ) / \
+            self.dx ) * (self.Hz[1:, :] - self.Hz[:-1, :]) )
 
-        self.Hz[1:-1, 1:-1] = self.Hz[1:-1, 1:-1] + dt / MU0 * (
-            (self.Ex[1:-1, 1:] - self.Ex[1:-1, :-1]) / self.dy -
-            (self.Ey[1:, 1:-1] - self.Ey[:-1, 1:-1]) / self.dx
-        )
+        # Update magnetic field
+        self.Hzx[1:-1, 1:-1] = ( 1 / (2 * MU0 + self.condPMLx[1:-1, 1:-1] * dt) ) * ( (2 * MU0 - self.condPMLx[1:-1, 1:-1] * dt) * self.Hzx[1:-1, 1:-1] - ( (2*dt) / self.dx ) * 
+            (self.Ey[1:, 1:-1] - self.Ey[:-1, 1:-1]) )
+        self.Hzy[1:-1, 1:-1] = ( 1 / (2 * MU0 + self.condPMLy[1:-1, 1:-1] * dt) ) * ( (2 * MU0 - self.condPMLy[1:-1, 1:-1] * dt) * self.Hzy[1:-1, 1:-1] + ( (2*dt) / self.dy ) *
+            (self.Ex[1:-1, 1:] - self.Ex[1:-1, :-1]) )
+
+        # Combine magnetic fields
+        self.Hz = self.Hzx + self.Hzy
 
         # PEC boundary conditions
         self.Hz[0, :] = 0.0
@@ -56,3 +92,35 @@ class FDTD2D:
             self.step(dt)
 
         return self.Hz 
+    
+    # Added function to visualize the simulation
+    def simulate_and_plot(self, Tf, dt, interval=10):
+        """
+        Simulates the evolution of the Hz field and visualizes it using matplotlib.
+
+        Parameters:
+        - Tf: Final simulation time.
+        - dt: Time step.
+        - interval: Number of steps between frames in the animation.
+        """
+        if not self.initialized:
+            raise RuntimeError(
+                "Initial condition not set. Call set_initial_condition first.")
+
+        n_steps = int(Tf / dt)
+
+        fig, ax = plt.subplots()
+        cax = ax.imshow(self.Hz, cmap='viridis', origin='lower', extent=[self.xE[0], self.xE[-1], self.yE[0], self.yE[-1]])
+        fig.colorbar(cax, ax=ax)
+        ax.set_title("Hz Field Evolution")
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+
+        def update(frame):
+            for _ in range(interval):
+                self.step(dt)
+            cax.set_array(self.Hz)
+            return cax,
+
+        ani = animation.FuncAnimation(fig, update, frames=n_steps // interval, blit=True)
+        plt.show()

--- a/test_fdtd2d.py
+++ b/test_fdtd2d.py
@@ -70,6 +70,49 @@ def test_fdtd_2d_solver_band_y():
     assert np.corrcoef(section_y, expected_y)[0, 1] >= 0.99
 
 
+def test_fdtd_2d_solver_PML_relection_coefficient():
+    nx, ny = 101, 101
+    L = 101
+    xE = np.linspace(-L/2, L/2, nx)
+    yE = np.linspace(-L/2, L/2, ny)
+
+    x0, y0 = 0.0, 0.0
+    sigma = 3.0
+
+    dx = xE[1] - xE[0]
+    dy = yE[1] - yE[0]
+    dt = 0.5 * np.sqrt(dx**2 + dy**2) / C0
+    Tf = L
+
+    #PML variables
+    R0=1.5e-6 #Reflection admited
+    m=2.82 # Steepness of the grading
+    thicknessPML=10 # Thickness of the PML in number of cells
+
+    # Set initial conditions to a gaussian pulse in x and y
+    initial_condition = np.zeros((nx, ny))
+    for i in range(nx):
+        for j in range(ny):
+            initial_condition[i, j] = gaussian_pulse(xE[i], x0, sigma) * gaussian_pulse(yE[j], y0, sigma)
+
+    solver = FDTD2D(xE, yE)
+    solver.set_initial_condition(initial_condition)
+
+    # Save initial Hz field
+    initial_Hz = np.max(solver.Hz.copy())
+
+    # Set PML
+    solver.set_PML(thicknessPML, m, R0, dx)
+
+    # Run the simulation
+    solver.run_until(Tf, dt)
+
+    # Check that the energy after the wave have passed through the PML is almost 0 in the whole grid
+    final_Hz = np.max(solver.Hz.copy())
+
+    assert final_Hz / initial_Hz < 0.01
+
+
 @pytest.mark.skip("Not really a test")
 def test_fdtd_2d_solver_gaussian():
     """Test 2D FDTD solver with a 2D Gaussian pulse initial condition."""
@@ -137,3 +180,27 @@ def test_fdtd_2d_solver_gaussian():
 
 if __name__ == "__main__":
     pytest.main([__file__]) 
+    # For plotting and testing
+    # Define grid
+    nx, ny = 101, 101
+    L = 101
+    xE = np.linspace(-L/2, L/2, nx)
+    yE = np.linspace(-L/2, L/2, ny)
+
+    x0, y0 = 0.0, 0.0
+    sigma = 3.0
+
+    # Create FDTD2D object
+    fdtd = FDTD2D(xE, yE)
+
+    # Set initial condition (e.g., Gaussian pulse) with the x0 and y0 and sigma defined above
+    X, Y = np.meshgrid(xE, yE, indexing='ij')
+    initial_condition = np.exp(-((X - x0)**2 + (Y - y0)**2) / (sigma**2))
+    fdtd.set_initial_condition(initial_condition)
+
+    
+    # Set PML (optional)
+    fdtd.set_PML(thicknessPML=10, m=2.82, R0=1.5e-6, dx=fdtd.dx)
+
+    # Simulate and plot
+    fdtd.simulate_and_plot(Tf=L, dt=0.5 * np.sqrt(fdtd.dx**2 + fdtd.dy**2) / C0, interval=3)


### PR DESCRIPTION
We, David González, Juan José Rojas and Sergio Rodríguez, have implemented PML absorbing boundary conditions to 2 dimensional FDTD. We had to change the differential scheme that was already implemented in order to add the magnetic conductivity which is fundamental for implementing the PML.

We have also added a test that ensures that the reflective coefficient is close to zero. This has been done by comparing the maximum value of the magnetic field in the initial condition and after being absorb by the PML.

PD: We have also made the changes requested for the 1 dimensional PML, which is the other pull request that our group has open.